### PR TITLE
Add connector state panel for CamelK specific connectors

### DIFF
--- a/resources/grafana/downstream/grafana-dashboard-dataplane-camelk-connector-view.yaml
+++ b/resources/grafana/downstream/grafana-dashboard-dataplane-camelk-connector-view.yaml
@@ -34,7 +34,8 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "iteration": 1668090357955,
+      "id": 27975,
+      "iteration": 1669905216039,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -816,6 +817,230 @@ data:
             "type": "prometheus",
             "uid": "${Datasource}"
           },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ready"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "failed_but_ready"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 41,
+          "options": {
+            "barRadius": 0,
+            "barWidth": 0.7,
+            "groupWidth": 0.7,
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "orientation": "auto",
+            "showValue": "never",
+            "stacking": "none",
+            "text": {},
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "xField": "Time",
+            "xTickLabelRotation": 0,
+            "xTickLabelSpacing": 100
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "editorMode": "code",
+              "expr": "clamp_max(increase(cos_fleetshard_sync_connector_state_count_total{cos_connector_id=\"$connector_id\"}[5m]), 1)",
+              "legendFormat": "{{cos_connector_state}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Connector State",
+          "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
+          "description": "Camel Exchange Processing Rate Per Second.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Datasource}"
+              },
+              "editorMode": "code",
+              "expr": "application_camel_exchange_processing_rate_per_second{cluster_id=\"$cluster_id\",namespace=\"$namespace\",connector_id=\"$connector_id\"}",
+              "legendFormat": "Exchange processing rate per second",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Exchange Processing Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Datasource}"
+          },
           "description": "Increase in the Exchange processing time series.",
           "fieldConfig": {
             "defaults": {
@@ -851,6 +1076,7 @@ data:
                 }
               },
               "mappings": [],
+              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -871,7 +1097,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 13
+            "y": 21
           },
           "id": 14,
           "options": {
@@ -961,7 +1187,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 13
+            "y": 21
           },
           "id": 13,
           "options": {
@@ -992,102 +1218,12 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Datasource}"
-          },
-          "description": "Camel Exchange Processing Rate Per Second.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 8,
-            "x": 16,
-            "y": 13
-          },
-          "id": 15,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${Datasource}"
-              },
-              "editorMode": "code",
-              "expr": "application_camel_exchange_processing_rate_per_second{cluster_id=\"$cluster_id\",namespace=\"$namespace\",connector_id=\"$connector_id\"}",
-              "legendFormat": "Exchange processing rate per second",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Exchange Processing Rate",
-          "type": "timeseries"
-        },
-        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 20
+            "y": 28
           },
           "id": 17,
           "panels": [],
@@ -1154,7 +1290,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 21
+            "y": 29
           },
           "id": 19,
           "options": {
@@ -1244,7 +1380,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 21
+            "y": 29
           },
           "id": 21,
           "options": {
@@ -1334,7 +1470,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 21
+            "y": 29
           },
           "id": 20,
           "options": {
@@ -1370,7 +1506,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 36
           },
           "id": 23,
           "panels": [],
@@ -1437,7 +1573,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 29
+            "y": 37
           },
           "id": 24,
           "options": {
@@ -1539,7 +1675,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 29
+            "y": 37
           },
           "id": 26,
           "options": {
@@ -1641,7 +1777,7 @@ data:
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 29
+            "y": 37
           },
           "id": 25,
           "options": {
@@ -1701,7 +1837,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 36
+            "y": 44
           },
           "id": 28,
           "panels": [],
@@ -1768,7 +1904,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 37
+            "y": 45
           },
           "id": 30,
           "options": {
@@ -1819,9 +1955,9 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
-              "text": "rhoc-observatorium-production",
-              "value": "rhoc-observatorium-production"
+              "selected": false,
+              "text": "rhoc-observatorium-stage",
+              "value": "rhoc-observatorium-stage"
             },
             "hide": 0,
             "includeAll": false,
@@ -1837,9 +1973,9 @@ data:
           },
           {
             "current": {
-              "selected": false,
-              "text": "None",
-              "value": ""
+              "selected": true,
+              "text": "cc6ae6o7764p8lrcfbj0",
+              "value": "cc6ae6o7764p8lrcfbj0"
             },
             "datasource": {
               "type": "prometheus",
@@ -1864,8 +2000,8 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "None",
-              "value": ""
+              "text": "redhat-openshift-connectors-cc6ae6o7764p8lrcfbk0",
+              "value": "redhat-openshift-connectors-cc6ae6o7764p8lrcfbk0"
             },
             "datasource": {
               "type": "prometheus",
@@ -1889,9 +2025,9 @@ data:
           },
           {
             "current": {
-              "selected": false,
-              "text": "None",
-              "value": ""
+              "selected": true,
+              "text": "cdl60jtajgdagid3bov0",
+              "value": "cdl60jtajgdagid3bov0"
             },
             "datasource": {
               "type": "prometheus",
@@ -1917,8 +2053,8 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "None",
-              "value": ""
+              "text": "mctr-cdl60k5ajgdagid3bp00",
+              "value": "mctr-cdl60k5ajgdagid3bp00"
             },
             "datasource": {
               "type": "prometheus",
@@ -1943,7 +2079,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-24h",
+        "from": "now-12h",
         "to": "now"
       },
       "timepicker": {},


### PR DESCRIPTION
This PR adds the Connector **State Panel** to the connector dashboard. A failing connector looks like this:

<img width="1721" alt="Screenshot 2022-12-01 at 16 28 00" src="https://user-images.githubusercontent.com/8087166/205094754-ade6aef4-84e9-44c6-832b-6bfbcca1bfd9.png">

A running connector looks like this:

<img width="1726" alt="Screenshot 2022-12-01 at 16 27 47" src="https://user-images.githubusercontent.com/8087166/205094779-f0a3e278-a70d-45f2-a9f9-9763465ae0e2.png">
