### PR TITLE
Include all Observatorium required fields for rules

### DIFF
--- a/resources/prometheus/downstream/camel-k-operator-rules.yaml
+++ b/resources/prometheus/downstream/camel-k-operator-rules.yaml
@@ -21,6 +21,7 @@ spec:
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CamelKOperatorContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
             service: 'rhoc-camel-k-operator'

--- a/resources/prometheus/downstream/connectors-slo-rules.yaml
+++ b/resources/prometheus/downstream/connectors-slo-rules.yaml
@@ -14,48 +14,64 @@ spec:
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[5m])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[5m])) )
           record: slo_connector_availability_failure_rate:ratio_rate5m
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[30m])) 
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[30m])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[30m])) )
           record: slo_connector_availability_failure_rate:ratio_rate30m
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[1h])) 
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[1h])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[1h])) )
           record: slo_connector_availability_failure_rate:ratio_rate1h
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[2h])) 
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[2h])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[2h])) )
           record: slo_connector_availability_failure_rate:ratio_rate2h
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[6h]))
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[6h])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[6h])) )
           record: slo_connector_availability_failure_rate:ratio_rate6h
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[12h]))
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[12h])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[12h])) )
           record: slo_connector_availability_failure_rate:ratio_rate12h
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[24h]))
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[24h])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[24h])) )
           record: slo_connector_availability_failure_rate:ratio_rate24h
+          labels:
+            tenant: rhoc
 
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[3d]))
             /
             ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[3d])) + sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[3d])) )
           record: slo_connector_availability_failure_rate:ratio_rate3d
+          labels:
+            tenant: rhoc
 
         - alert: RHOCConnectorsAvailability5mTo1hOr30mTo6hP2BudgetBurn
           expr: |
@@ -70,6 +86,7 @@ spec:
               AND
               slo_connector_availability_failure_rate:ratio_rate30m > (6 * (1 - 0.995))
             )
+          for: 1m
           labels:
             severity: critical
           annotations:
@@ -91,6 +108,7 @@ spec:
               AND
               slo_connector_availability_failure_rate:ratio_rate6h > (1 * (1 - 0.995))
             )
+          for: 1m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
@@ -20,6 +20,7 @@ spec:
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorCamelContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
@@ -20,6 +20,7 @@ spec:
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
@@ -20,6 +20,7 @@ spec:
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardSyncContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/downstream/strimzi-operator-rules.yaml
+++ b/resources/prometheus/downstream/strimzi-operator-rules.yaml
@@ -20,6 +20,7 @@ spec:
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: StrimziOperatorContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/unit_tests/connectors-slo-rules-test.yaml
+++ b/resources/prometheus/unit_tests/connectors-slo-rules-test.yaml
@@ -47,46 +47,46 @@ tests:
       - expr: slo_connector_availability_failure_rate:ratio_rate5m
         eval_time: 24h20m
         exp_samples:
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cafmth1l8123ida8obm0"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 0.25
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cchi5bvod5s2tjbeh7ag"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 0
       - expr: slo_connector_availability_failure_rate:ratio_rate5m
         eval_time: 24h40m
         exp_samples:
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cafmth1l8123ida8obm0"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 0.25
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cchi5bvod5s2tjbeh7ag"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 0
       - expr: slo_connector_availability_failure_rate:ratio_rate5m
         eval_time: 25h10m
         exp_samples:
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cafmth1l8123ida8obm0"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 0.50
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cchi5bvod5s2tjbeh7ag"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate5m{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 0
 
       # slo_connector_availability_failure_rate:ratio_rate1h
       - expr: slo_connector_availability_failure_rate:ratio_rate1h
         eval_time: 24h20m
         exp_samples:
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cafmth1l8123ida8obm0"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 8.750000000000001E-02
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cchi5bvod5s2tjbeh7ag"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 0
       - expr: slo_connector_availability_failure_rate:ratio_rate1h
         eval_time: 24h40m
         exp_samples:
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cafmth1l8123ida8obm0"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 1.7083333333333334E-01
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cchi5bvod5s2tjbeh7ag"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 0
       - expr: slo_connector_availability_failure_rate:ratio_rate1h
         eval_time: 25h10m
         exp_samples:
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cafmth1l8123ida8obm0"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 2.9583333333333334E-01
-          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cchi5bvod5s2tjbeh7ag"}'
+          - labels: 'slo_connector_availability_failure_rate:ratio_rate1h{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 0
 
     alert_rule_test:
@@ -107,6 +107,7 @@ tests:
           - exp_labels:
               alertname: RHOCConnectorsAvailability5mTo1hOr30mTo6hP2BudgetBurn
               cluster_id: cafmth1l8123ida8obm0
+              tenant: rhoc
               severity: critical
             exp_annotations:
               summary: "High 1h/6h Connectors availability budget burn for RHOC (current value: 87.5m)"
@@ -119,6 +120,7 @@ tests:
           - exp_labels:
               alertname: RHOCConnectorsAvailability5mTo1hOr30mTo6hP2BudgetBurn
               cluster_id: cafmth1l8123ida8obm0
+              tenant: rhoc
               severity: critical
             exp_annotations:
               summary: "High 1h/6h Connectors availability budget burn for RHOC (current value: 295.8m)"
@@ -143,6 +145,7 @@ tests:
           - exp_labels:
               alertname: RHOCConnectorsAvailability2hTo24HOr6hTo3dBudgetBurn
               cluster_id: cafmth1l8123ida8obm0
+              tenant: rhoc
               severity: critical
             exp_annotations:
               summary: "High 3d/24h Connectors availability budget burn for RHOC (current value: 5.269m)"


### PR DESCRIPTION
- include `for` in alerts
- include `labels` for recorded rules. This one makes little sense to me and I could not think of any meanfull label we could use so I am adding `tenant=rhoc` which is pretty dumb but hey ...