### PR TITLE
Group alerts by cluster_id

### DIFF
--- a/resources/prometheus/downstream/camel-k-operator-rules.yaml
+++ b/resources/prometheus/downstream/camel-k-operator-rules.yaml
@@ -11,24 +11,23 @@ spec:
       interval: 10m
       rules:
         - alert: CamelKOperatorTargetDown
-          expr: up{container="camel-k-operator"} !=1 or absent(up{container="camel-k-operator"})
+          expr: group by (cluster_id) (up{container="camel-k-operator"} !=1 or absent(up{container="camel-k-operator"}))
           for: 10m
           labels:
             severity: critical
-            service: 'rhoc-camel-k-operator'
           annotations:
             summary: 'the camel-k operator target is down'
             description: |
-              the camel-k operator target has been unable to sync the {{ $labels.container }}
-              container in the {{ $labels.namespace }} namespace for longer than 10 minutes
+              prometheus has been unable to scrape the camel-k operator pod in the
+              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CamelKOperatorContainerFrequentlyRestarting
-          expr: increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m]) > 3
+          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m]) > 3)
           for: 10m
           labels:
             severity: critical
-            service: 'rhoc-camel-k-operator'
           annotations:
-            summary: 'the camel-k operator is restarting frequently'
+            summary: |
+              the camel-k operator pod is restarting frequently in cluster: {{ $labels.cluster_id }}
             description: 'the camel-k operator container restarted frequently in the last 60 minutes'
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
@@ -11,22 +11,23 @@ spec:
       interval: 10m
       rules:
         - alert: CosFleetShardOperatorCamelTargetDown
-          expr: up{container="cos-fleetshard-operator-camel"} !=1 or absent(up{container="cos-fleetshard-operator-camel"})
+          expr: group by (cluster_id) (up{container="cos-fleetshard-operator-camel"} !=1 or absent(up{container="cos-fleetshard-operator-camel"}))
           for: 10m
           labels:
             severity: critical
           annotations:
             summary: 'the cos-fleetshard-operator-camel target is down'
             description: |
-              the cos-fleetshard-operator-camel target has been unable to scrape the {{ $labels.container }}
-              container in the {{ $labels.namespace }} namespace for longer than 10 minutes
+              prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
+              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorCamelContainerFrequentlyRestarting
-          expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m]) > 3
+          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m]) > 3)
           for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-camel operator is restarting frequently'
+            summary: |
+              the cos-fleetshard-operator-camel pod is restarting frequently in cluster: {{ $labels.cluster_id }}
             description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
@@ -11,22 +11,23 @@ spec:
       interval: 10m
       rules:
         - alert: CosFleetShardOperatorDebeziumTargetDown
-          expr: up{container="cos-fleetshard-operator-debezium"} !=1 or absent(up{container="cos-fleetshard-operator-debezium"})
+          expr: group by (cluster_id) (up{container="cos-fleetshard-operator-debezium"} !=1 or absent(up{container="cos-fleetshard-operator-debezium"}))
           for: 10m
           labels:
             severity: critical
           annotations:
             summary: 'the cos-fleetshard-operator-debezium target is down'
             description: |
-              the cos-fleetshard-operator-debezium target has been unable to scrape the {{ $labels.container }}
-              container in the {{ $labels.namespace }} namespace for longer than 10 minutes
+              prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
+              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
-          expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m]) > 3
+          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m]) > 3)
           for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-debezium operator is restarting frequently'
+            summary: |
+              the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: {{ $labels.cluster_id }}
             description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
@@ -11,22 +11,23 @@ spec:
       interval: 10m
       rules:
         - alert: CosFleetShardSyncTargetDown
-          expr: up{container="cos-fleetshard-sync"} !=1 or absent(up{container="cos-fleetshard-sync"})
+          expr: group by (cluster_id) (up{container="cos-fleetshard-sync"} !=1 or absent(up{container="cos-fleetshard-sync"}))
           for: 10m
           labels:
             severity: critical
           annotations:
             summary: 'the cos-fleetshard-sync target is down'
             description: |
-              the cos-fleetshard-sync target has been unable to scrape the {{ $labels.container }}
-              container in the {{ $labels.namespace }} namespace for longer than 10 minutes
+              prometheus has been unable to scrape the cos-fleetshard-sync pod in the
+              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardSyncContainerFrequentlyRestarting
-          expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]) > 3
+          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]) > 3)
           for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-sync operator is restarting frequently'
+            summary: |
+              the cos-fleetshard-sync pod is restarting frequently in cluster: {{ $labels.cluster_id }}
             description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/strimzi-operator-rules.yaml
+++ b/resources/prometheus/downstream/strimzi-operator-rules.yaml
@@ -11,22 +11,23 @@ spec:
       interval: 10m
       rules:
         - alert: StrimziOperatorTargetDown
-          expr: up{container="strimzi-cluster-operator"} !=1 or absent(up{container="strimzi-cluster-operator"})
+          expr: group by (cluster_id) (up{container="strimzi-cluster-operator"} !=1 or absent(up{container="strimzi-cluster-operator"}))
           for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the strimzi operator target is down'
+            summary: 'the strimzi-cluster-operator target is down'
             description: |
-              the strimzi operator target has been unable to scrape the {{ $labels.container }}
-              container in the {{ $labels.namespace }} namespace for longer than 10 minutes'
+              prometheus has been unable to scrape the strimzi-cluster-operator pod in the
+              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: StrimziOperatorContainerFrequentlyRestarting
-          expr: increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m]) > 3
+          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m]) > 3)
           for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the strimzi operator is restarting frequently'
-            description: 'the strimzi operator container restarted frequently in the last 60 minutes'
+            summary: |
+              the strimzi-cluster-operator pod is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/unit_tests/camel-k-operator-rules-test.yaml
+++ b/resources/prometheus/unit_tests/camel-k-operator-rules-test.yaml
@@ -6,10 +6,23 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{container="camel-k-operator", namespace="some_namespace"}'
-        values: '1+0x30 0+0x30 1+0x30'
-      - series: 'kube_pod_container_status_restarts_total{container="camel-k-operator", namespace="some_namespace"}'
-        values: '0+0x30 1+1x30 0+0x100'
+      - series: 'up{container="camel-k-operator", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '1+0x30 0+0x30 1+0x120'
+      - series: 'up{container="camel-k-operator", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '1+0x180'
+      - series: 'up{container="camel-k-operator", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '1+0x60 0+0x60 1+0x60'
+      - series: 'up{container="camel-k-operator", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '1+0x90 0+0x30 1+0x60'
+
+      - series: 'kube_pod_container_status_restarts_total{container="camel-k-operator", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '0+0x30 1+1x30 0+0x180'
+      - series: 'kube_pod_container_status_restarts_total{container="camel-k-operator", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '0+0x240'
+      - series: 'kube_pod_container_status_restarts_total{container="camel-k-operator", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '0+0x60 1+1x60 0+0x120'
+      - series: 'kube_pod_container_status_restarts_total{container="camel-k-operator", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '0+0x120 1+1x30 0+0x90'
 
     alert_rule_test:
       # CamelKOperatorTargetDown test units
@@ -22,18 +35,52 @@ tests:
           - exp_labels:
               alertname: CamelKOperatorTargetDown
               severity: critical
-              service: 'rhoc-camel-k-operator'
-              container: 'camel-k-operator'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: 'the camel-k operator target is down'
               description: |
-                the camel-k operator target has been unable to sync the camel-k-operator
-                container in the some_namespace namespace for longer than 10 minutes
+                prometheus has been unable to scrape the camel-k operator pod in the
+                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
-      - eval_time: 70m
+      - eval_time: 80m
         alertname: CamelKOperatorTargetDown
-        exp_alerts: [ ]
+        exp_alerts:
+          - exp_labels:
+              alertname: CamelKOperatorTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the camel-k operator target is down'
+              description: |
+                prometheus has been unable to scrape the camel-k operator pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 115m
+        alertname: CamelKOperatorTargetDown
+        exp_alerts:
+          - exp_labels:
+              alertname: CamelKOperatorTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the camel-k operator target is down'
+              description: |
+                prometheus has been unable to scrape the camel-k operator pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CamelKOperatorTargetDown
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: 'the camel-k operator target is down'
+              description: |
+                prometheus has been unable to scrape the camel-k operator pod in the
+                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 150m
+        alertname: CamelKOperatorTargetDown
+        exp_alerts: []
 
       # CamelKOperatorContainerFrequentlyRestarting test units
       - eval_time: 10m
@@ -45,13 +92,45 @@ tests:
           - exp_labels:
               alertname: CamelKOperatorContainerFrequentlyRestarting
               severity: critical
-              service: 'rhoc-camel-k-operator'
-              container: 'camel-k-operator'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the camel-k operator is restarting frequently'
+              summary: |
+                the camel-k operator pod is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 130m
+        alertname: CamelKOperatorContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CamelKOperatorContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the camel-k operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
               description: 'the camel-k operator container restarted frequently in the last 60 minutes'
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
+        alertname: CamelKOperatorContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CamelKOperatorContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the camel-k operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CamelKOperatorContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: |
+                the camel-k operator pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 230m
         alertname: CamelKOperatorContainerFrequentlyRestarting
         exp_alerts: [ ]

--- a/resources/prometheus/unit_tests/cos-fleedshard-operator-camel-rules-test.yaml
+++ b/resources/prometheus/unit_tests/cos-fleedshard-operator-camel-rules-test.yaml
@@ -6,10 +6,23 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{container="cos-fleetshard-operator-camel", namespace="some_namespace"}'
-        values: '1+0x30 0+0x30 1+0x30'
-      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel", namespace="some_namespace"}'
-        values: '0+0x30 1+1x30 0+0x100'
+      - series: 'up{container="cos-fleetshard-operator-camel", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '1+0x30 0+0x30 1+0x120'
+      - series: 'up{container="cos-fleetshard-operator-camel", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '1+0x180'
+      - series: 'up{container="cos-fleetshard-operator-camel", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '1+0x60 0+0x60 1+0x60'
+      - series: 'up{container="cos-fleetshard-operator-camel", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '1+0x90 0+0x30 1+0x60'
+
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '0+0x30 1+1x30 0+0x180'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '0+0x240'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '0+0x60 1+1x60 0+0x120'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '0+0x120 1+1x30 0+0x90'
 
     alert_rule_test:
       # CosFleetShardOperatorCamelTargetDown test units
@@ -22,17 +35,52 @@ tests:
           - exp_labels:
               alertname: CosFleetShardOperatorCamelTargetDown
               severity: critical
-              container: 'cos-fleetshard-operator-camel'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: 'the cos-fleetshard-operator-camel target is down'
               description: |
-                the cos-fleetshard-operator-camel target has been unable to scrape the cos-fleetshard-operator-camel
-                container in the some_namespace namespace for longer than 10 minutes
+                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
+                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
-      - eval_time: 70m
+      - eval_time: 80m
         alertname: CosFleetShardOperatorCamelTargetDown
-        exp_alerts: [ ]
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorCamelTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the cos-fleetshard-operator-camel target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 115m
+        alertname: CosFleetShardOperatorCamelTargetDown
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorCamelTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the cos-fleetshard-operator-camel target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CosFleetShardOperatorCamelTargetDown
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: 'the cos-fleetshard-operator-camel target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
+                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 150m
+        alertname: CosFleetShardOperatorCamelTargetDown
+        exp_alerts: []
 
       # CosFleetShardOperatorCamelContainerFrequentlyRestarting test units
       - eval_time: 10m
@@ -44,12 +92,45 @@ tests:
           - exp_labels:
               alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
               severity: critical
-              container: 'cos-fleetshard-operator-camel'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-camel operator is restarting frequently'
+              summary: |
+                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 130m
+        alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
               description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
+        alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 230m
         alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
         exp_alerts: [ ]

--- a/resources/prometheus/unit_tests/cos-fleedshard-operator-debezium-rules-test.yaml
+++ b/resources/prometheus/unit_tests/cos-fleedshard-operator-debezium-rules-test.yaml
@@ -6,10 +6,23 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{container="cos-fleetshard-operator-debezium", namespace="some_namespace"}'
-        values: '1+0x30 0+0x30 1+0x30'
-      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium", namespace="some_namespace"}'
-        values: '0+0x30 1+1x30 0+0x100'
+      - series: 'up{container="cos-fleetshard-operator-debezium", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '1+0x30 0+0x30 1+0x120'
+      - series: 'up{container="cos-fleetshard-operator-debezium", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '1+0x180'
+      - series: 'up{container="cos-fleetshard-operator-debezium", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '1+0x60 0+0x60 1+0x60'
+      - series: 'up{container="cos-fleetshard-operator-debezium", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '1+0x90 0+0x30 1+0x60'
+
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '0+0x30 1+1x30 0+0x180'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '0+0x240'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '0+0x60 1+1x60 0+0x120'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '0+0x120 1+1x30 0+0x90'
 
     alert_rule_test:
       # CosFleetShardOperatorDebeziumTargetDown test units
@@ -22,19 +35,54 @@ tests:
           - exp_labels:
               alertname: CosFleetShardOperatorDebeziumTargetDown
               severity: critical
-              container: 'cos-fleetshard-operator-debezium'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: 'the cos-fleetshard-operator-debezium target is down'
               description: |
-                the cos-fleetshard-operator-debezium target has been unable to scrape the cos-fleetshard-operator-debezium
-                container in the some_namespace namespace for longer than 10 minutes
+                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
+                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
-      - eval_time: 70m
+      - eval_time: 80m
         alertname: CosFleetShardOperatorDebeziumTargetDown
-        exp_alerts: [ ]
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorDebeziumTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the cos-fleetshard-operator-debezium target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 115m
+        alertname: CosFleetShardOperatorDebeziumTargetDown
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorDebeziumTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the cos-fleetshard-operator-debezium target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CosFleetShardOperatorDebeziumTargetDown
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: 'the cos-fleetshard-operator-debezium target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
+                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 150m
+        alertname: CosFleetShardOperatorDebeziumTargetDown
+        exp_alerts: []
 
-      # CosFleetShardOperatordebeziumContainerFrequentlyRestarting test units
+      # CosFleetShardOperatorDebeziumContainerFrequentlyRestarting test units
       - eval_time: 10m
         alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
         exp_alerts: [ ]
@@ -44,12 +92,45 @@ tests:
           - exp_labels:
               alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
               severity: critical
-              container: 'cos-fleetshard-operator-debezium'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-debezium operator is restarting frequently'
+              summary: |
+                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 130m
+        alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
               description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
+        alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 230m
         alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
         exp_alerts: [ ]

--- a/resources/prometheus/unit_tests/cos-fleedshard-sync-rules-test.yaml
+++ b/resources/prometheus/unit_tests/cos-fleedshard-sync-rules-test.yaml
@@ -6,10 +6,23 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{container="cos-fleetshard-sync", namespace="some_namespace"}'
-        values: '1+0x30 0+0x30 1+0x30'
-      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-sync", namespace="some_namespace"}'
-        values: '0+0x30 1+1x30 0+0x100'
+      - series: 'up{container="cos-fleetshard-sync", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '1+0x30 0+0x30 1+0x120'
+      - series: 'up{container="cos-fleetshard-sync", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '1+0x180'
+      - series: 'up{container="cos-fleetshard-sync", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '1+0x60 0+0x60 1+0x60'
+      - series: 'up{container="cos-fleetshard-sync", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '1+0x90 0+0x30 1+0x60'
+
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-sync", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '0+0x30 1+1x30 0+0x180'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-sync", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '0+0x240'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-sync", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '0+0x60 1+1x60 0+0x120'
+      - series: 'kube_pod_container_status_restarts_total{container="cos-fleetshard-sync", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '0+0x120 1+1x30 0+0x90'
 
     alert_rule_test:
       # CosFleetShardSyncTargetDown test units
@@ -22,17 +35,52 @@ tests:
           - exp_labels:
               alertname: CosFleetShardSyncTargetDown
               severity: critical
-              container: 'cos-fleetshard-sync'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: 'the cos-fleetshard-sync target is down'
               description: |
-                the cos-fleetshard-sync target has been unable to scrape the cos-fleetshard-sync
-                container in the some_namespace namespace for longer than 10 minutes
+                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
+                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
-      - eval_time: 70m
+      - eval_time: 80m
         alertname: CosFleetShardSyncTargetDown
-        exp_alerts: [ ]
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardSyncTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the cos-fleetshard-sync target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 115m
+        alertname: CosFleetShardSyncTargetDown
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardSyncTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the cos-fleetshard-sync target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CosFleetShardSyncTargetDown
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: 'the cos-fleetshard-sync target is down'
+              description: |
+                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
+                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 150m
+        alertname: CosFleetShardSyncTargetDown
+        exp_alerts: []
 
       # CosFleetShardSyncContainerFrequentlyRestarting test units
       - eval_time: 10m
@@ -44,12 +92,45 @@ tests:
           - exp_labels:
               alertname: CosFleetShardSyncContainerFrequentlyRestarting
               severity: critical
-              container: 'cos-fleetshard-sync'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the cos-fleetshard-sync operator is restarting frequently'
+              summary: |
+                the cos-fleetshard-sync pod is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 130m
+        alertname: CosFleetShardSyncContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardSyncContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-sync pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
               description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
+        alertname: CosFleetShardSyncContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: CosFleetShardSyncContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-sync pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: CosFleetShardSyncContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: |
+                the cos-fleetshard-sync pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 230m
         alertname: CosFleetShardSyncContainerFrequentlyRestarting
         exp_alerts: [ ]

--- a/resources/prometheus/unit_tests/strimzi-operator-rules-test.yaml
+++ b/resources/prometheus/unit_tests/strimzi-operator-rules-test.yaml
@@ -6,10 +6,23 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{container="strimzi-cluster-operator", namespace="some_namespace"}'
-        values: '1+0x30 0+0x30 1+0x30'
-      - series: 'kube_pod_container_status_restarts_total{container="strimzi-cluster-operator", namespace="some_namespace"}'
-        values: '0+0x30 1+1x30 0+0x100'
+      - series: 'up{container="strimzi-cluster-operator", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '1+0x30 0+0x30 1+0x120'
+      - series: 'up{container="strimzi-cluster-operator", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '1+0x180'
+      - series: 'up{container="strimzi-cluster-operator", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '1+0x60 0+0x60 1+0x60'
+      - series: 'up{container="strimzi-cluster-operator", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '1+0x90 0+0x30 1+0x60'
+
+      - series: 'kube_pod_container_status_restarts_total{container="strimzi-cluster-operator", cluster_id="cafmth1l8123ida8obm0"}'
+        values: '0+0x30 1+1x30 0+0x180'
+      - series: 'kube_pod_container_status_restarts_total{container="strimzi-cluster-operator", cluster_id="cchi5bvod5s2tjbeh7ag"}'
+        values: '0+0x240'
+      - series: 'kube_pod_container_status_restarts_total{container="strimzi-cluster-operator", cluster_id="ce85sscmo9pbcfol9e9g"}'
+        values: '0+0x60 1+1x60 0+0x120'
+      - series: 'kube_pod_container_status_restarts_total{container="strimzi-cluster-operator", cluster_id="ce8q91ug0sma721hcokg"}'
+        values: '0+0x120 1+1x30 0+0x90'
 
     alert_rule_test:
       # StrimziOperatorTargetDown test units
@@ -22,17 +35,52 @@ tests:
           - exp_labels:
               alertname: StrimziOperatorTargetDown
               severity: critical
-              container: 'strimzi-cluster-operator'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the strimzi operator target is down'
+              summary: 'the strimzi-cluster-operator target is down'
               description: |
-                the strimzi operator target has been unable to scrape the strimzi-cluster-operator
-                container in the some_namespace namespace for longer than 10 minutes'
+                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
+                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
-      - eval_time: 70m
+      - eval_time: 80m
         alertname: StrimziOperatorTargetDown
-        exp_alerts: [ ]
+        exp_alerts:
+          - exp_labels:
+              alertname: StrimziOperatorTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the strimzi-cluster-operator target is down'
+              description: |
+                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 115m
+        alertname: StrimziOperatorTargetDown
+        exp_alerts:
+          - exp_labels:
+              alertname: StrimziOperatorTargetDown
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: 'the strimzi-cluster-operator target is down'
+              description: |
+                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
+                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: StrimziOperatorTargetDown
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: 'the strimzi-cluster-operator target is down'
+              description: |
+                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
+                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 150m
+        alertname: StrimziOperatorTargetDown
+        exp_alerts: []
 
       # StrimziOperatorContainerFrequentlyRestarting test units
       - eval_time: 10m
@@ -44,12 +92,45 @@ tests:
           - exp_labels:
               alertname: StrimziOperatorContainerFrequentlyRestarting
               severity: critical
-              container: 'strimzi-cluster-operator'
-              namespace: 'some_namespace'
+              cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the strimzi operator is restarting frequently'
-              description: 'the strimzi operator container restarted frequently in the last 60 minutes'
+              summary: |
+                the strimzi-cluster-operator pod is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 130m
+        alertname: StrimziOperatorContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: StrimziOperatorContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the strimzi-cluster-operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
+        alertname: StrimziOperatorContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: StrimziOperatorContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce85sscmo9pbcfol9e9g
+            exp_annotations:
+              summary: |
+                the strimzi-cluster-operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+          - exp_labels:
+              alertname: StrimziOperatorContainerFrequentlyRestarting
+              severity: critical
+              cluster_id: ce8q91ug0sma721hcokg
+            exp_annotations:
+              summary: |
+                the strimzi-cluster-operator pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+              sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
+      - eval_time: 230m
         alertname: StrimziOperatorContainerFrequentlyRestarting
         exp_alerts: [ ]


### PR DESCRIPTION
- since alerts will be running in Observatorium, it is necessary to group by cluster_id now.
- some formating of summary and description
- change summary to a less wordy sentence