### PR TITLE
MGDCTRS-1794: fix *ContainerFrequentlyRestarting alert expr

### DIFF
--- a/resources/prometheus/downstream/camel-k-operator-rules.yaml
+++ b/resources/prometheus/downstream/camel-k-operator-rules.yaml
@@ -22,7 +22,7 @@ spec:
               cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CamelKOperatorContainerFrequentlyRestarting
-          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m]) > 3)
+          expr: sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m])) > 3
           for: 10m
           labels:
             severity: critical

--- a/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
@@ -22,7 +22,7 @@ spec:
               cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorCamelContainerFrequentlyRestarting
-          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m]) > 3)
+          expr: sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m])) > 3
           for: 10m
           labels:
             severity: critical

--- a/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
@@ -22,7 +22,7 @@ spec:
               cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
-          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m]) > 3)
+          expr: sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m])) > 3
           for: 10m
           labels:
             severity: critical

--- a/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
@@ -22,7 +22,7 @@ spec:
               cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardSyncContainerFrequentlyRestarting
-          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]) > 3)
+          expr: sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m])) > 3
           for: 10m
           labels:
             severity: critical

--- a/resources/prometheus/downstream/strimzi-operator-rules.yaml
+++ b/resources/prometheus/downstream/strimzi-operator-rules.yaml
@@ -22,7 +22,7 @@ spec:
               cluster: {{ $labels.cluster_id }} for longer than 10 minutes
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: StrimziOperatorContainerFrequentlyRestarting
-          expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m]) > 3)
+          expr: sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m])) > 3
           for: 10m
           labels:
             severity: critical


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

When expressions are evaluated in Observatorium, `*ContainerFrequentlyRestarting` alerts don't trigger if the container is deleted, causing more than one pod being present in the last hour. By using `sum` through all containers, we get the right results.

For instance, I manually deleted the sync pod in a dev cluster and changed the deployment to make it crash, this is the result after a while, notice **it doesn't increase the counter**.
```
$ group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]))

{
        "status": "success",
        "data": {
                "resultType": "vector",
                "result": [
                        {
                                "metric": {
                                        "cluster_id": "ca34tqpnnj5k851srhjg"
                                },
                                "value": [
                                        1671007573.926,
                                        "1"
                                ]
                        },
                        {
                                "metric": {
                                        "cluster_id": "cc6ae6o7764p8lrcfbj0"
                                },
                                "value": [
                                        1671007573.926,
                                        "1"
                                ]
                        }
                ]
        }
}
```

But in reality, the pod is restarting, the problem is that we have now two pods in the last 60 minutes, the one I killed initially and the one trying to start:
```
{
        "status": "success",
        "data": {
                "resultType": "vector",
                "result": [
                        {
                                "metric": {
                                        "cluster_id": "ca34tqpnnj5k851srhjg",
                                        "container": "cos-fleetshard-sync",
                                        "endpoint": "https-main",
                                        "job": "kube-state-metrics",
                                        "namespace": "redhat-openshift-connectors",
                                        "pod": "cos-fleetshard-sync-6dd4794c5b-q522c",
                                        "prometheus": "openshift-monitoring/k8s",
                                        "receive": "true",
                                        "service": "kube-state-metrics",
                                        "tenant_id": "2dd839e2-cf2b-424a-add4-2e826b7541ee",
                                        "uid": "fe022700-d0d1-4c92-8be3-1dce2c13e0af"
                                },
                                "value": [
                                        1671007618.617,
                                        "0"
                                ]
                        },
                        {
                                "metric": {
                                        "cluster_id": "ca34tqpnnj5k851srhjg",
                                        "container": "cos-fleetshard-sync",
                                        "endpoint": "https-main",
                                        "job": "kube-state-metrics",
                                        "namespace": "redhat-openshift-connectors",
                                        "pod": "cos-fleetshard-sync-8679445876-2nh5k",
                                        "prometheus": "openshift-monitoring/k8s",
                                        "receive": "true",
                                        "service": "kube-state-metrics",
                                        "tenant_id": "2dd839e2-cf2b-424a-add4-2e826b7541ee",
                                        "uid": "2da94a99-8ead-4537-930a-46714d9d0b6e"
                                },
                                "value": [
                                        1671007618.617,
                                        "9.007552827039312"
                                ]
                        }
                ]
        }
}
```

By summing instead of grouping we get the right results:
```
$ obsctl  metrics query 'sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m])) > 3'                                                 
{                                                                                                                                                                                                                   
        "status": "success",                                                                                                                                                                                        
        "data": {                                                                                                                                                                                                   
                "resultType": "vector",                                                                                                                                                                             
                "result": [                                                                                                                                                                                         
                        {                                                                                                                                                                                           
                                "metric": {                                                                                                                                                                         
                                        "cluster_id": "ca34tqpnnj5k851srhjg"                                                                                                                                        
                                },                                                                                                                                                                                  
                                "value": [                                                                                                                                                                          
                                        1671007714.352,                                                                                                                                                             
                                        "8.7688902950698"                                                                                                                                                           
                                ]                                                                                                                                                                                   
                        }                                                                                                                                                                                           
                ]                                                                                                                                                                                                   
        }                                                                                                                                                                                                           
}
```
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
1. Go to a dev cluster, delete the sync pod and change the Deployment so the pod doesn't start forcing it to be restarted. 
2. Wait 10 minutes and run `group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]))`. See all values set to 1, it should be something different.
3. Run `obsctl  metrics query 'sum by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]))'` and see how the value reflects the pod restarting.
## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Verified independently by reviewer
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~

## Prometheus
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies prometheus resources
-->
- [x] Changes were tested against dev environment

## Grafana
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies grafana resources
-->
~~- [ ] You have imported the changes into a dev or staging environment~~