### PR TITLE
MGDCTRS-1795: Improve summary for *TargetDown and *ContainerFrequentlyRestarting alerts

### DIFF
--- a/resources/prometheus/camel-k-operator-rules.yaml
+++ b/resources/prometheus/camel-k-operator-rules.yaml
@@ -13,17 +13,21 @@ spec:
           for: 10m
           labels:
             severity: critical
-            service: 'rhoc-camel-k-operator'
           annotations:
-            summary: 'the camel-k operator target is down'
-            description: 'the camel-k operator target has been unable to sync the {{ $labels.container }} container in the {{ $labels.namespace }} namespace for longer than 10 minutes'
+            summary: |
+              the camelk operator is down
+            description: |
+              prometheus was unable to scrape the camelk operator for longer than 10 minutes.
+              This most likely means that the camelk operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CamelKOperatorContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
-            service: 'rhoc-camel-k-operator'
           annotations:
-            summary: 'the camel-k operator is restarting frequently'
-            description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+            summary: |
+              the camelk operator is restarting frequently
+            description: |
+              in the previous 60 minutes, the camelk operator restarted frequently(more than 3 times)
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/cos-fleetshard-operator-camel-rules.yaml
+++ b/resources/prometheus/cos-fleetshard-operator-camel-rules.yaml
@@ -14,14 +14,20 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-camel target is down'
-            description: 'the cos-fleetshard-operator-camel target has been unable to scrape the {{ $labels.container }} container in the {{ $labels.namespace }} namespace for longer than 10 minutes'
+            summary: |
+              the fleetshard-camel operator is down
+            description: |
+              prometheus was unable to scrape the fleetshard-camel operator for longer than 10 minutes.
+              This most likely means that the fleetshard-camel operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorCamelContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-camel operator is restarting frequently'
-            description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+            summary: |
+              the fleetshard-camel operator is restarting frequently
+            description: |
+              in the previous 60 minutes, the fleetshard-camel operator restarted frequently(more than 3 times)
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/cos-fleetshard-operator-debezium-rules.yaml
+++ b/resources/prometheus/cos-fleetshard-operator-debezium-rules.yaml
@@ -14,14 +14,19 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-debezium target is down'
-            description: 'the cos-fleetshard-operator-debezium target has been unable to scrape the {{ $labels.container }} container in the {{ $labels.namespace }} namespace for longer than 10 minutes'
+            summary: |
+              the fleetshard-debezium operator is down
+            description: |
+              prometheus was unable to scrape the fleetshard-debezium operatorfor longer than 10 minutes.
+              This most likely means that the fleetshard-debezium operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-debezium operator is restarting frequently'
-            description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+            the fleetshard-debezium operator is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: |
+              in the previous 60 minutes, the fleetshard-debezium operator restarted frequently(more than 3 times)
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/cos-fleetshard-sync-rules.yaml
+++ b/resources/prometheus/cos-fleetshard-sync-rules.yaml
@@ -14,15 +14,21 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-sync target is down'
-            description: 'the cos-fleetshard-sync target has been unable to scrape the {{ $labels.container }} container in the {{ $labels.namespace }} namespace for longer than 10 minutes'
+            summary: |
+              the fleetshard-sync operator is down
+            description: |
+              prometheus was unable to scrape the fleetshard-sync operator for longer than 10 minutes.
+              This most likely means that the fleetshard-sync operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardSyncContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-sync operator is restarting frequently'
-            description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+            summary: |
+              the fleetshard-sync operator is restarting frequently
+            description: |
+              in the previous 60 minutes, the fleetshard-sync operator restarted frequently(more than 3 times)
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
 

--- a/resources/prometheus/downstream/camel-k-operator-rules.yaml
+++ b/resources/prometheus/downstream/camel-k-operator-rules.yaml
@@ -16,10 +16,11 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the camel-k operator target is down'
+            summary: |
+              the camelk operator is down in cluster: {{ $labels.cluster_id }}
             description: |
-              prometheus has been unable to scrape the camel-k operator pod in the
-              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
+              prometheus was unable to scrape the camelk operator in the cluster: {{ $labels.cluster_id }} for longer than 10 minutes.
+              This most likely means that the camelk operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CamelKOperatorContainerFrequentlyRestarting
           expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="camel-k-operator"}[60m]) > 3)
@@ -28,6 +29,8 @@ spec:
             severity: critical
           annotations:
             summary: |
-              the camel-k operator pod is restarting frequently in cluster: {{ $labels.cluster_id }}
-            description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+              the camelk operator is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: |
+              in the previous 60 minutes, the camelk operator restarted frequently(more than 3 times)
+              in cluster: {{ $labels.cluster_id }}
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-camel-rules.yaml
@@ -16,10 +16,11 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-camel target is down'
+            summary: |
+              the fleetshard-camel operator is down in cluster: {{ $labels.cluster_id }}
             description: |
-              prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
-              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
+              prometheus was unable to scrape the fleetshard-camel operator in the cluster: {{ $labels.cluster_id }} for longer than 10 minutes.
+              This most likely means that the fleetshard-camel operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorCamelContainerFrequentlyRestarting
           expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-camel"}[60m]) > 3)
@@ -28,6 +29,8 @@ spec:
             severity: critical
           annotations:
             summary: |
-              the cos-fleetshard-operator-camel pod is restarting frequently in cluster: {{ $labels.cluster_id }}
-            description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+              the fleetshard-camel operator is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: |
+              in the previous 60 minutes, the fleetshard-camel operator restarted frequently(more than 3 times)
+              in cluster: {{ $labels.cluster_id }}
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-operator-debezium-rules.yaml
@@ -16,10 +16,11 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-operator-debezium target is down'
+            summary: |
+              the fleetshard-debezium operator is down in cluster: {{ $labels.cluster_id }}
             description: |
-              prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
-              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
+              prometheus was unable to scrape the fleetshard-debezium operator in the cluster: {{ $labels.cluster_id }} for longer than 10 minutes.
+              This most likely means that the fleetshard-debezium operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
           expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-operator-debezium"}[60m]) > 3)
@@ -28,6 +29,8 @@ spec:
             severity: critical
           annotations:
             summary: |
-              the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: {{ $labels.cluster_id }}
-            description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+              the fleetshard-debezium operator is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: |
+              in the previous 60 minutes, the fleetshard-debezium operator restarted frequently(more than 3 times)
+              in cluster: {{ $labels.cluster_id }}
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
+++ b/resources/prometheus/downstream/cos-fleetshard-sync-rules.yaml
@@ -16,10 +16,11 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the cos-fleetshard-sync target is down'
+            summary: |
+              the fleetshard-sync operator is down in cluster: {{ $labels.cluster_id }}
             description: |
-              prometheus has been unable to scrape the cos-fleetshard-sync pod in the
-              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
+              prometheus was unable to scrape the fleetshard-sync operator in the cluster: {{ $labels.cluster_id }} for longer than 10 minutes.
+              This most likely means that the fleetshard-sync operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: CosFleetShardSyncContainerFrequentlyRestarting
           expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="cos-fleetshard-sync"}[60m]) > 3)
@@ -28,6 +29,8 @@ spec:
             severity: critical
           annotations:
             summary: |
-              the cos-fleetshard-sync pod is restarting frequently in cluster: {{ $labels.cluster_id }}
-            description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+              the fleetshard-sync operator is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: |
+              in the previous 60 minutes, the fleetshard-sync operator restarted frequently(more than 3 times)
+              in cluster: {{ $labels.cluster_id }}
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/downstream/strimzi-operator-rules.yaml
+++ b/resources/prometheus/downstream/strimzi-operator-rules.yaml
@@ -16,10 +16,11 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the strimzi-cluster-operator target is down'
+            summary: |
+              the debezium operator is down in cluster: {{ $labels.cluster_id }}
             description: |
-              prometheus has been unable to scrape the strimzi-cluster-operator pod in the
-              cluster: {{ $labels.cluster_id }} for longer than 10 minutes
+              prometheus was unable to scrape the debezium operator in the cluster: {{ $labels.cluster_id }} for longer than 10 minutes.
+              This most likely means that the debezium operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: StrimziOperatorContainerFrequentlyRestarting
           expr: group by (cluster_id) (increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m]) > 3)
@@ -28,6 +29,8 @@ spec:
             severity: critical
           annotations:
             summary: |
-              the strimzi-cluster-operator pod is restarting frequently in cluster: {{ $labels.cluster_id }}
-            description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+              the debezium operator is restarting frequently in cluster: {{ $labels.cluster_id }}
+            description: |
+              in the previous 60 minutes, the debezium operator restarted frequently(more than 3 times)
+              in cluster: {{ $labels.cluster_id }}
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/strimzi-operator-rules.yaml
+++ b/resources/prometheus/strimzi-operator-rules.yaml
@@ -14,14 +14,20 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: 'the strimzi operator target is down'
-            description: 'the strimzi operator target has been unable to scrape the {{ $labels.container }} container in the {{ $labels.namespace }} namespace for longer than 10 minutes'
+            summary: |
+              the debezium operator is down
+            description: |
+              prometheus was unable to scrape the debezium operator for longer than 10 minutes.
+              This most likely means that the debezium operator pod is unable to start
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
         - alert: StrimziOperatorContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{container="strimzi-cluster-operator"}[60m]) > 3
+          for: 10m
           labels:
             severity: critical
           annotations:
-            summary: 'the strimzi operator is restarting frequently'
-            description: 'the strimzi operator container restarted frequently in the last 60 minutes'
+            summary: |
+              the debezium operator is restarting frequently
+            description: |
+              in the previous 60 minutes, the debezium operator restarted frequently(more than 3 times)
             sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'

--- a/resources/prometheus/unit_tests/camel-k-operator-rules-test.yaml
+++ b/resources/prometheus/unit_tests/camel-k-operator-rules-test.yaml
@@ -37,10 +37,11 @@ tests:
               severity: critical
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the camel-k operator target is down'
+              summary: |
+                the camelk operator is down in cluster: cafmth1l8123ida8obm0
               description: |
-                prometheus has been unable to scrape the camel-k operator pod in the
-                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
+                prometheus was unable to scrape the camelk operator in the cluster: cafmth1l8123ida8obm0 for longer than 10 minutes.
+                This most likely means that the camelk operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 80m
         alertname: CamelKOperatorTargetDown
@@ -50,10 +51,11 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the camel-k operator target is down'
+              summary: |
+                the camelk operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the camel-k operator pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the camelk operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the camelk operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 115m
         alertname: CamelKOperatorTargetDown
@@ -63,20 +65,22 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the camel-k operator target is down'
+              summary: |
+                the camelk operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the camel-k operator pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the camelk operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the camelk operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CamelKOperatorTargetDown
               severity: critical
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
-              summary: 'the camel-k operator target is down'
+              summary: |
+                the camelk operator is down in cluster: ce8q91ug0sma721hcokg
               description: |
-                prometheus has been unable to scrape the camel-k operator pod in the
-                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+                prometheus was unable to scrape the camelk operator in the cluster: ce8q91ug0sma721hcokg for longer than 10 minutes.
+                This most likely means that the camelk operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 150m
         alertname: CamelKOperatorTargetDown
@@ -95,8 +99,10 @@ tests:
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: |
-                the camel-k operator pod is restarting frequently in cluster: cafmth1l8123ida8obm0
-              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+                the camelk operator is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: |
+                in the previous 60 minutes, the camelk operator restarted frequently(more than 3 times)
+                in cluster: cafmth1l8123ida8obm0
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 130m
         alertname: CamelKOperatorContainerFrequentlyRestarting
@@ -107,8 +113,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the camel-k operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+                the camelk operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the camelk operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
         alertname: CamelKOperatorContainerFrequentlyRestarting
@@ -119,8 +127,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the camel-k operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+                the camelk operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the camelk operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CamelKOperatorContainerFrequentlyRestarting
@@ -128,8 +138,10 @@ tests:
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
               summary: |
-                the camel-k operator pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
-              description: 'the camel-k operator container restarted frequently in the last 60 minutes'
+                the camelk operator is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: |
+                in the previous 60 minutes, the camelk operator restarted frequently(more than 3 times)
+                in cluster: ce8q91ug0sma721hcokg
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 230m
         alertname: CamelKOperatorContainerFrequentlyRestarting

--- a/resources/prometheus/unit_tests/cos-fleedshard-operator-camel-rules-test.yaml
+++ b/resources/prometheus/unit_tests/cos-fleedshard-operator-camel-rules-test.yaml
@@ -37,10 +37,11 @@ tests:
               severity: critical
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-camel target is down'
+              summary: |
+                the fleetshard-camel operator is down in cluster: cafmth1l8123ida8obm0
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
-                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-camel operator in the cluster: cafmth1l8123ida8obm0 for longer than 10 minutes.
+                This most likely means that the fleetshard-camel operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 80m
         alertname: CosFleetShardOperatorCamelTargetDown
@@ -50,10 +51,11 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-camel target is down'
+              summary: |
+                the fleetshard-camel operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-camel operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the fleetshard-camel operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 115m
         alertname: CosFleetShardOperatorCamelTargetDown
@@ -63,20 +65,22 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-camel target is down'
+              summary: |
+                the fleetshard-camel operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-camel operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the fleetshard-camel operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CosFleetShardOperatorCamelTargetDown
               severity: critical
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-camel target is down'
+              summary: |
+                the fleetshard-camel operator is down in cluster: ce8q91ug0sma721hcokg
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-camel pod in the
-                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-camel operator in the cluster: ce8q91ug0sma721hcokg for longer than 10 minutes.
+                This most likely means that the fleetshard-camel operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 150m
         alertname: CosFleetShardOperatorCamelTargetDown
@@ -95,8 +99,10 @@ tests:
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: cafmth1l8123ida8obm0
-              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+                the fleetshard-camel operator is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: |
+                in the previous 60 minutes, the fleetshard-camel operator restarted frequently(more than 3 times)
+                in cluster: cafmth1l8123ida8obm0
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 130m
         alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
@@ -107,8 +113,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+                the fleetshard-camel operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the fleetshard-camel operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
         alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
@@ -119,8 +127,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+                the fleetshard-camel operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the fleetshard-camel operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting
@@ -128,8 +138,10 @@ tests:
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-camel pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
-              description: 'the cos-fleetshard-operator-camel operator container restarted frequently in the last 60 minutes'
+                the fleetshard-camel operator is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: |
+                in the previous 60 minutes, the fleetshard-camel operator restarted frequently(more than 3 times)
+                in cluster: ce8q91ug0sma721hcokg
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 230m
         alertname: CosFleetShardOperatorCamelContainerFrequentlyRestarting

--- a/resources/prometheus/unit_tests/cos-fleedshard-operator-debezium-rules-test.yaml
+++ b/resources/prometheus/unit_tests/cos-fleedshard-operator-debezium-rules-test.yaml
@@ -37,10 +37,11 @@ tests:
               severity: critical
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-debezium target is down'
+              summary: |
+                the fleetshard-debezium operator is down in cluster: cafmth1l8123ida8obm0
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
-                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-debezium operator in the cluster: cafmth1l8123ida8obm0 for longer than 10 minutes.
+                This most likely means that the fleetshard-debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 80m
         alertname: CosFleetShardOperatorDebeziumTargetDown
@@ -50,10 +51,11 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-debezium target is down'
+              summary: |
+                the fleetshard-debezium operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-debezium operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the fleetshard-debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 115m
         alertname: CosFleetShardOperatorDebeziumTargetDown
@@ -63,20 +65,22 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-debezium target is down'
+              summary: |
+                the fleetshard-debezium operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-debezium operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the fleetshard-debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CosFleetShardOperatorDebeziumTargetDown
               severity: critical
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
-              summary: 'the cos-fleetshard-operator-debezium target is down'
+              summary: |
+                the fleetshard-debezium operator is down in cluster: ce8q91ug0sma721hcokg
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-operator-debezium pod in the
-                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-debezium operator in the cluster: ce8q91ug0sma721hcokg for longer than 10 minutes.
+                This most likely means that the fleetshard-debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 150m
         alertname: CosFleetShardOperatorDebeziumTargetDown
@@ -95,8 +99,10 @@ tests:
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: cafmth1l8123ida8obm0
-              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+                the fleetshard-debezium operator is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: |
+                in the previous 60 minutes, the fleetshard-debezium operator restarted frequently(more than 3 times)
+                in cluster: cafmth1l8123ida8obm0
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 130m
         alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
@@ -107,8 +113,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+                the fleetshard-debezium operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the fleetshard-debezium operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
         alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
@@ -119,8 +127,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+                the fleetshard-debezium operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the fleetshard-debezium operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting
@@ -128,8 +138,10 @@ tests:
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
               summary: |
-                the cos-fleetshard-operator-debezium pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
-              description: 'the cos-fleetshard-operator-debezium operator container restarted frequently in the last 60 minutes'
+                the fleetshard-debezium operator is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: |
+                in the previous 60 minutes, the fleetshard-debezium operator restarted frequently(more than 3 times)
+                in cluster: ce8q91ug0sma721hcokg
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 230m
         alertname: CosFleetShardOperatorDebeziumContainerFrequentlyRestarting

--- a/resources/prometheus/unit_tests/cos-fleedshard-sync-rules-test.yaml
+++ b/resources/prometheus/unit_tests/cos-fleedshard-sync-rules-test.yaml
@@ -37,10 +37,11 @@ tests:
               severity: critical
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the cos-fleetshard-sync target is down'
+              summary: |
+                the fleetshard-sync operator is down in cluster: cafmth1l8123ida8obm0
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
-                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-sync operator in the cluster: cafmth1l8123ida8obm0 for longer than 10 minutes.
+                This most likely means that the fleetshard-sync operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 80m
         alertname: CosFleetShardSyncTargetDown
@@ -50,10 +51,11 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the cos-fleetshard-sync target is down'
+              summary: |
+                the fleetshard-sync operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-sync operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the fleetshard-sync operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 115m
         alertname: CosFleetShardSyncTargetDown
@@ -63,20 +65,22 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the cos-fleetshard-sync target is down'
+              summary: |
+                the fleetshard-sync operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-sync operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the fleetshard-sync operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CosFleetShardSyncTargetDown
               severity: critical
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
-              summary: 'the cos-fleetshard-sync target is down'
+              summary: |
+                the fleetshard-sync operator is down in cluster: ce8q91ug0sma721hcokg
               description: |
-                prometheus has been unable to scrape the cos-fleetshard-sync pod in the
-                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+                prometheus was unable to scrape the fleetshard-sync operator in the cluster: ce8q91ug0sma721hcokg for longer than 10 minutes.
+                This most likely means that the fleetshard-sync operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 150m
         alertname: CosFleetShardSyncTargetDown
@@ -95,8 +99,10 @@ tests:
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: |
-                the cos-fleetshard-sync pod is restarting frequently in cluster: cafmth1l8123ida8obm0
-              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+                the fleetshard-sync operator is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: |
+                in the previous 60 minutes, the fleetshard-sync operator restarted frequently(more than 3 times)
+                in cluster: cafmth1l8123ida8obm0
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 130m
         alertname: CosFleetShardSyncContainerFrequentlyRestarting
@@ -107,8 +113,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the cos-fleetshard-sync pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+                the fleetshard-sync operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the fleetshard-sync operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
         alertname: CosFleetShardSyncContainerFrequentlyRestarting
@@ -119,8 +127,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the cos-fleetshard-sync pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+                the fleetshard-sync operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the fleetshard-sync operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: CosFleetShardSyncContainerFrequentlyRestarting
@@ -128,8 +138,10 @@ tests:
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
               summary: |
-                the cos-fleetshard-sync pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
-              description: 'the cos-fleetshard-sync operator container restarted frequently in the last 60 minutes'
+                the fleetshard-sync operator is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: |
+                in the previous 60 minutes, the fleetshard-sync operator restarted frequently(more than 3 times)
+                in cluster: ce8q91ug0sma721hcokg
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 230m
         alertname: CosFleetShardSyncContainerFrequentlyRestarting

--- a/resources/prometheus/unit_tests/strimzi-operator-rules-test.yaml
+++ b/resources/prometheus/unit_tests/strimzi-operator-rules-test.yaml
@@ -37,10 +37,11 @@ tests:
               severity: critical
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
-              summary: 'the strimzi-cluster-operator target is down'
+              summary: |
+                the debezium operator is down in cluster: cafmth1l8123ida8obm0
               description: |
-                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
-                cluster: cafmth1l8123ida8obm0 for longer than 10 minutes
+                prometheus was unable to scrape the debezium operator in the cluster: cafmth1l8123ida8obm0 for longer than 10 minutes.
+                This most likely means that the debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 80m
         alertname: StrimziOperatorTargetDown
@@ -50,10 +51,11 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the strimzi-cluster-operator target is down'
+              summary: |
+                the debezium operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the debezium operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 115m
         alertname: StrimziOperatorTargetDown
@@ -63,20 +65,22 @@ tests:
               severity: critical
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
-              summary: 'the strimzi-cluster-operator target is down'
+              summary: |
+                the debezium operator is down in cluster: ce85sscmo9pbcfol9e9g
               description: |
-                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
-                cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes
+                prometheus was unable to scrape the debezium operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes.
+                This most likely means that the debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: StrimziOperatorTargetDown
               severity: critical
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
-              summary: 'the strimzi-cluster-operator target is down'
+              summary: |
+                the debezium operator is down in cluster: ce8q91ug0sma721hcokg
               description: |
-                prometheus has been unable to scrape the strimzi-cluster-operator pod in the
-                cluster: ce8q91ug0sma721hcokg for longer than 10 minutes
+                prometheus was unable to scrape the debezium operator in the cluster: ce8q91ug0sma721hcokg for longer than 10 minutes.
+                This most likely means that the debezium operator pod is unable to start
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 150m
         alertname: StrimziOperatorTargetDown
@@ -95,8 +99,10 @@ tests:
               cluster_id: cafmth1l8123ida8obm0
             exp_annotations:
               summary: |
-                the strimzi-cluster-operator pod is restarting frequently in cluster: cafmth1l8123ida8obm0
-              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+                the debezium operator is restarting frequently in cluster: cafmth1l8123ida8obm0
+              description: |
+                in the previous 60 minutes, the debezium operator restarted frequently(more than 3 times)
+                in cluster: cafmth1l8123ida8obm0
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 130m
         alertname: StrimziOperatorContainerFrequentlyRestarting
@@ -107,8 +113,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the strimzi-cluster-operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+                the debezium operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the debezium operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 160m
         alertname: StrimziOperatorContainerFrequentlyRestarting
@@ -119,8 +127,10 @@ tests:
               cluster_id: ce85sscmo9pbcfol9e9g
             exp_annotations:
               summary: |
-                the strimzi-cluster-operator pod is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
-              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+                the debezium operator is restarting frequently in cluster: ce85sscmo9pbcfol9e9g
+              description: |
+                in the previous 60 minutes, the debezium operator restarted frequently(more than 3 times)
+                in cluster: ce85sscmo9pbcfol9e9g
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
           - exp_labels:
               alertname: StrimziOperatorContainerFrequentlyRestarting
@@ -128,8 +138,10 @@ tests:
               cluster_id: ce8q91ug0sma721hcokg
             exp_annotations:
               summary: |
-                the strimzi-cluster-operator pod is restarting frequently in cluster: ce8q91ug0sma721hcokg
-              description: 'the strimzi-cluster-operator container restarted frequently in the last 60 minutes'
+                the debezium operator is restarting frequently in cluster: ce8q91ug0sma721hcokg
+              description: |
+                in the previous 60 minutes, the debezium operator restarted frequently(more than 3 times)
+                in cluster: ce8q91ug0sma721hcokg
               sop_url: 'https://github.com/bf2fc6cc711aee1a0c2a/cos-sre-sops/blob/main/sops/alerts/container_down.adoc'
       - eval_time: 230m
         alertname: StrimziOperatorContainerFrequentlyRestarting


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Introduce better summary and description messages for  *TargetDown and *ContainerFrequentlyRestarting  downstream and legacy rules.

For instance, currently when an alert trigger for the fleetshard-camel operator, summary and description are shown as following:
```
summary: the cos-fleetshard-operator-camel target is down
description: the cos-fleetshard-operator-camel target has been unable to scrape the cos-fleetshard-operator-camel container in the redhat-openshift-connectors namespace for longer than 10 minutes
 ```

 a better message would be:
 ```
summary: the fleetshard-camel operator is down
description: prometheus was unable to scrape the fleetshard-camel operator for longer than 10 minutes. This most likely means that the fleetshard-camel operator pod is unable to start
```

For downstream alerting rules, the **cluster_id** can be included as following:
```
summary: the fleetshard-camel operator is down in cluster: ce85sscmo9pbcfol9e9g
description: prometheus was unable to scrape the fleetshard-camel operator in the cluster: ce85sscmo9pbcfol9e9g for longer than 10 minutes. This most likely means that the fleetshard-camel operator pod is unable to start
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Verified independently by reviewer
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~

## Prometheus
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies prometheus resources
-->
- [x] Changes were tested against dev environment

## Grafana
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies grafana resources
-->
~~- [ ] You have imported the changes into a dev or staging environment~~