### PR TITLE
MGDCTRS-1796: Drop labels that aren't used in rules or dashboards

### DIFF
--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -1,4 +1,8 @@
 writeRelabelConfigs:
+  # Drop useless labels
+  - action: labeldrop
+    regex: endpoint|instance|job|prometheus|pod
+
   # WHAT: Reports the current amount of samples that have failed to be sent to observatorium
   - action: replace
     regex: prometheus_remote_storage_failed_samples_total$


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed. Screenshots are also welcome -->

Before sending metrics to Observatorium, drops useless labels that increase cardinality and give little to no information.

```
$ obsctl  metrics query 'up{cluster_id="$cluster_id", container="strimzi-cluster-operator"}'
{
        "status": "success",
        "data": {
                "resultType": "vector",
                "result": [
                        {
                                "metric": {
                                        "__name__": "up",
                                        "cluster_id": "$cluster_id",
                                        "container": "strimzi-cluster-operator",
                                        "endpoint": "http",
                                        "instance": "10.128.6.28:8080",
                                        "job": "redhat-openshift-connectors-observability/strimzi-metrics",
                                        "namespace": "redhat-openshift-connectors",
                                        "pod": "strimzi-cluster-operator-5cf866ccd4-grmgg",
                                        "prometheus": "redhat-openshift-connectors-observability/kafka-prometheus",
                                        "receive": "true",
                                        "tenant_id": "2dd839e2-cf2b-424a-add4-2e826b7541ee"
                                },
                                "value": [
                                        1671032202.876,
                                        "1"
                                ]
                        }
                ]
        }
}
```

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->
1. Log onto a dev cluster and point the cos-fleetshard-observability-upstream to `https://github.com/lgarciaaco/cos-observability-resources/tree/_drop_labels`.
2. Delete the Observability CR and the cos-fleetshard-sync running pod. The sync pod should get recreated and the Observability CR too.
3. Wait from few minutes and run the same query as above. The result should not include any of the undesired labels.
```
$ obsctl  metrics query 'up{cluster_id="$cluster_id", container="strimzi-cluster-operator"}'
{
        "status": "success",
        "data": {
                "resultType": "vector",
                "result": [
                        {
                                "metric": {
                                        "__name__": "up",
                                        "cluster_id": "$cluster_id",
                                        "container": "strimzi-cluster-operator",
                                        "namespace": "redhat-openshift-connectors",
                                        "receive": "true"
                                },
                                "value": [
                                        1671032202.876,
                                        "1"
                                ]
                        }
                ]
        }
}
```

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
~~- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)~~
- [ ] Verified independently by reviewer
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~

## Prometheus
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies prometheus resources
-->
- [x] Changes were tested against dev environment

## Grafana
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies grafana resources
-->
~~- [ ] You have imported the changes into a dev or staging environment~~