### PR TITLE
MGDCTRS-1703: Added Recording rules for the data-plane SLO Grafana dashboard

### DIFF
--- a/resources/prometheus/downstream/connectors-slo-rules.yaml
+++ b/resources/prometheus/downstream/connectors-slo-rules.yaml
@@ -106,6 +106,93 @@ spec:
           labels:
             tenant: rhoc
 
+        - expr: |
+            sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
+            /
+            ( 
+              sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d])) + ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0) )
+            )
+          record: slo_connector_availability_success_rate:ratio_rate7d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+            sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
+            /
+            (
+              sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) + ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0) ) 
+            )
+          record: slo_connector_availability_success_rate:ratio_rate28d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+            (
+              ( 
+                0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
+              ) - (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
+            ) / 
+            ( 
+              0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
+            )
+          record: slo_connector_availability_remaining_error_budget:ratio_rate28d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+            (
+              ( 
+                0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
+              ) - (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
+            ) / 
+            ( 
+              0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
+            )
+          record: slo_connector_availability_remaining_error_budget:ratio_rate7d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+            ( 
+              ( 
+                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005) - ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[28d])) OR on() vector(0) )
+              ) 
+              / 
+              (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
+            )
+          record: slo_connector_data_remaining_error_budget:ratio_rate28d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+            ( 
+              ( 
+                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005) - ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[7d])) OR on() vector(0) )
+              ) 
+              / 
+              (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005)
+            )
+          record: slo_connector_data_remaining_error_budget:ratio_rate7d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+            sum by (cluster_id) (rate(application_camel_context_exchanges_completed_total[28d]))
+            /
+            sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d]))
+          record: slo_connector_data_success_rate:ratio_rate28d
+          labels:
+            tenant: rhoc
+
+        - expr: |
+              sum by (cluster_id) (rate(application_camel_context_exchanges_completed_total[7d]))
+              /
+              sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d]))
+          record: slo_connector_data_success_rate:ratio_rate7d
+          labels:
+            tenant: rhoc
+
+
         - alert: RHOCConnectorsAvailability5mTo1hOr30mTo6hP2BudgetBurn
           expr: |
             (

--- a/resources/prometheus/downstream/connectors-slo-rules.yaml
+++ b/resources/prometheus/downstream/connectors-slo-rules.yaml
@@ -131,77 +131,85 @@ spec:
             tenant: rhoc
 
         - expr: |
-            (
-              ( 
-                0.005 * 
+            clamp_min(
+              (
                 ( 
-                  sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) 
-                  + 
-                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) 
-                )
-              ) 
-              - 
-              (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
-            ) / 
-            ( 
-              0.005 *
+                  0.005 * 
+                  ( 
+                    sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) 
+                    + 
+                    (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) 
+                  )
+                ) 
+                - 
+                (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
+              ) / 
               ( 
-                sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
-                +
-                (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
-            )
+                0.005 *
+                ( 
+                  sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
+                  +
+                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
+              )
+            , 0)
           record: slo_connector_availability_remaining_error_budget:ratio_rate28d
           labels:
             tenant: rhoc
 
         - expr: |
-            (
+            clamp_min(
+              (
+                ( 
+                  0.005 * 
+                  (
+                    sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
+                    + 
+                    (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) 
+                  )
+                ) 
+                -
+                (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
+              ) / 
               ( 
-                0.005 * 
+                0.005 *
                 (
                   sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
-                  + 
-                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) 
-                )
-              ) 
-              -
-              (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
-            ) / 
-            ( 
-              0.005 *
-              (
-                sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
-                +
-                (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
-            )
+                  +
+                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
+              )
+            , 0)
           record: slo_connector_availability_remaining_error_budget:ratio_rate7d
           labels:
             tenant: rhoc
 
         - expr: |
-            ( 
+            clamp_min(
               ( 
+                ( 
+                  (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
+                  - 
+                  ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[28d])) OR on() vector(0) )
+                ) 
+                / 
                 (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
-                - 
-                ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[28d])) OR on() vector(0) )
-              ) 
-              / 
-              (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
-            )
+              )
+            , 0)
           record: slo_connector_data_remaining_error_budget:ratio_rate28d
           labels:
             tenant: rhoc
 
         - expr: |
-            ( 
+            clamp_min(
               ( 
-                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005) 
-                - 
-                ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[7d])) OR on() vector(0) )
-              ) 
-              / 
-              (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005)
-            )
+                ( 
+                  (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005) 
+                  - 
+                  ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[7d])) OR on() vector(0) )
+                ) 
+                / 
+                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005)
+              )
+            , 0)
           record: slo_connector_data_remaining_error_budget:ratio_rate7d
           labels:
             tenant: rhoc

--- a/resources/prometheus/downstream/connectors-slo-rules.yaml
+++ b/resources/prometheus/downstream/connectors-slo-rules.yaml
@@ -109,7 +109,7 @@ spec:
         - expr: |
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
             /
-            ( 
+            (
               sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
               +
               ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0) )
@@ -124,7 +124,7 @@ spec:
             (
               sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
               +
-              ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0) ) 
+              ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0) )
             )
           record: slo_connector_availability_success_rate:ratio_rate28d
           labels:
@@ -133,20 +133,24 @@ spec:
         - expr: |
             clamp_min(
               (
-                ( 
-                  0.005 * 
-                  ( 
-                    sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) 
-                    + 
-                    (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) 
+                (
+                  0.005 *
+                  (
+                    sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
+                    +
+                    (
+                      sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d]))
+                      OR
+                      on() vector(0)
+                    )
                   )
-                ) 
-                - 
+                )
+                -
                 (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
-              ) / 
-              ( 
+              ) /
+              (
                 0.005 *
-                ( 
+                (
                   sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
                   +
                   (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
@@ -159,18 +163,18 @@ spec:
         - expr: |
             clamp_min(
               (
-                ( 
-                  0.005 * 
+                (
+                  0.005 *
                   (
                     sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
-                    + 
-                    (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) 
+                    +
+                    (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
                   )
-                ) 
+                )
                 -
                 (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
-              ) / 
-              ( 
+              ) /
+              (
                 0.005 *
                 (
                   sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
@@ -184,13 +188,13 @@ spec:
 
         - expr: |
             clamp_min(
-              ( 
-                ( 
+              (
+                (
                   (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
-                  - 
+                  -
                   ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[28d])) OR on() vector(0) )
-                ) 
-                / 
+                )
+                /
                 (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
               )
             , 0)
@@ -200,13 +204,13 @@ spec:
 
         - expr: |
             clamp_min(
-              ( 
-                ( 
-                  (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005) 
-                  - 
+              (
+                (
+                  (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005)
+                  -
                   ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[7d])) OR on() vector(0) )
-                ) 
-                / 
+                )
+                /
                 (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005)
               )
             , 0)

--- a/resources/prometheus/downstream/connectors-slo-rules.yaml
+++ b/resources/prometheus/downstream/connectors-slo-rules.yaml
@@ -110,7 +110,9 @@ spec:
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
             /
             ( 
-              sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d])) + ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0) )
+              sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
+              +
+              ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0) )
             )
           record: slo_connector_availability_success_rate:ratio_rate7d
           labels:
@@ -120,7 +122,9 @@ spec:
             sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
             /
             (
-              sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) + ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0) ) 
+              sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
+              +
+              ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0) ) 
             )
           record: slo_connector_availability_success_rate:ratio_rate28d
           labels:
@@ -129,11 +133,22 @@ spec:
         - expr: |
             (
               ( 
-                0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
-              ) - (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
+                0.005 * 
+                ( 
+                  sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) 
+                  + 
+                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) 
+                )
+              ) 
+              - 
+              (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
             ) / 
             ( 
-              0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
+              0.005 *
+              ( 
+                sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
+                +
+                (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
             )
           record: slo_connector_availability_remaining_error_budget:ratio_rate28d
           labels:
@@ -142,11 +157,22 @@ spec:
         - expr: |
             (
               ( 
-                0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
-              ) - (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
+                0.005 * 
+                (
+                  sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
+                  + 
+                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) 
+                )
+              ) 
+              -
+              (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
             ) / 
             ( 
-              0.005 * ( sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d])) + (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
+              0.005 *
+              (
+                sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
+                +
+                (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
             )
           record: slo_connector_availability_remaining_error_budget:ratio_rate7d
           labels:
@@ -155,7 +181,9 @@ spec:
         - expr: |
             ( 
               ( 
-                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005) - ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[28d])) OR on() vector(0) )
+                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
+                - 
+                ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[28d])) OR on() vector(0) )
               ) 
               / 
               (sum by (cluster_id) (rate(application_camel_context_exchanges_total[28d])) * 0.005)
@@ -167,7 +195,9 @@ spec:
         - expr: |
             ( 
               ( 
-                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005) - ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[7d])) OR on() vector(0) )
+                (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005) 
+                - 
+                ( sum by (cluster_id) (rate(application_camel_context_exchanges_failed_total[7d])) OR on() vector(0) )
               ) 
               / 
               (sum by (cluster_id) (rate(application_camel_context_exchanges_total[7d])) * 0.005)

--- a/resources/prometheus/downstream/connectors-slo-rules.yaml
+++ b/resources/prometheus/downstream/connectors-slo-rules.yaml
@@ -153,7 +153,8 @@ spec:
                 (
                   sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[28d]))
                   +
-                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0)) )
+                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[28d])) OR on() vector(0))
+                )
               )
             , 0)
           record: slo_connector_availability_remaining_error_budget:ratio_rate28d
@@ -179,7 +180,8 @@ spec:
                 (
                   sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="ready"}[7d]))
                   +
-                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0)) )
+                  (sum by (cluster_id) (rate(cos_fleetshard_sync_connector_state_count_total{cos_connector_state="failed_but_ready"}[7d])) OR on() vector(0))
+                )
               )
             , 0)
           record: slo_connector_availability_remaining_error_budget:ratio_rate7d

--- a/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-1.yaml
+++ b/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-1.yaml
@@ -7,90 +7,118 @@ tests:
   - interval: 1m
     input_series:
       - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn60", cos_connector_state="ready"}'
-        values: '1+1x8639'
+        values: '1+1x359'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn60", cos_connector_state="failed_but_ready"}'
+        values: '0+0x359'
 
-      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="ready"}'
-        values: '1+1x4319'
-      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="failed_but_ready"}'
-        values: '0+0x4319 1+1x4319'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cafmth1l8123ida8obm0", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="ready"}'
+        values: '1+1x179'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cafmth1l8123ida8obm0", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="failed_but_ready"}'
+        values: '0+0x179 1+1x179'
 
       - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn62", cos_connector_state="ready"}'
-        values: '1+1x8639'
+        values: '1+1x359'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn62", cos_connector_state="failed_but_ready"}'
+        values: '0+0x359'
 
       - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
-        values: '1+1x8639'
+        values: '1+1x359'
       - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
-        values: '1+1x8639'
+        values: '1+1x359'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
+        values: '0+0x359'
 
-      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
-        values: '1+1x4319'
-      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
-        values: '1+1x8639'
-      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
-        values: '0+0x4319 1+1x4319'
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cafmth1l8123ida8obm0", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x179'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cafmth1l8123ida8obm0", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x359'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cafmth1l8123ida8obm0", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '0+0x179 1+1x179'
 
       - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn62"}'
-        values: '1+1x8639'
+        values: '1+1x359'
       - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn62"}'
-        values: '1+1x8639'
+        values: '1+1x359'
       - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn62"}'
-        values: '0+0x4319'
+        values: '0+0x359'
 
     promql_expr_test:
       #Testing Availability SLO
       - expr: slo_connector_availability_success_rate:ratio_rate7d
-        eval_time: 4319m
+        eval_time: 179m
         exp_samples:
           - labels: 'slo_connector_availability_success_rate:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_availability_success_rate:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 1
       - expr: slo_connector_availability_success_rate:ratio_rate7d
-        eval_time: 6d
+        eval_time: 359m
         exp_samples:
           - labels: 'slo_connector_availability_success_rate:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 8.33333331472789E-01
+            value: 1
+          - labels: 'slo_connector_availability_success_rate:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 5.006934812760054E-01
       - expr: slo_connector_availability_success_rate:ratio_rate28d
-        eval_time: 7d
+        eval_time: 7h
         exp_samples:
           - labels: 'slo_connector_availability_success_rate:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 8.333349398047781E-01
+            value: 1
+          - labels: 'slo_connector_availability_success_rate:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 5.003455344974693E-01
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
-        eval_time: 4319m
+        eval_time: 179m
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
-        eval_time: 4319m
+        eval_time: 179m
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
-        eval_time: 7d
+        eval_time: 7h
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 0
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
-        eval_time: 6d
+        eval_time: 6h
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 0
       #Testing Data Process SLO
       - expr: slo_connector_data_success_rate:ratio_rate28d
-        eval_time: 7d
+        eval_time: 7h
         exp_samples:
           - labels: 'slo_connector_data_success_rate:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 8.333429778369307E-01
+            value: 1
+          - labels: 'slo_connector_data_success_rate:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 5.006934812760055E-01
       - expr: slo_connector_data_success_rate:ratio_rate7d
-        eval_time: 4319m
+        eval_time: 3h
         exp_samples:
           - labels: 'slo_connector_data_success_rate:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_data_success_rate:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
       - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
-        eval_time: 4319m
+        eval_time: 179m
         exp_samples:
           - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
       - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
-        eval_time: 6d
+        eval_time: 6h
         exp_samples:
           - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 0

--- a/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-1.yaml
+++ b/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-1.yaml
@@ -1,0 +1,96 @@
+rule_files:
+  - /prometheus/rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn60", cos_connector_state="ready"}'
+        values: '1+1x8639'
+
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="ready"}'
+        values: '1+1x4319'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="failed_but_ready"}'
+        values: '0+0x4319 1+1x4319'
+
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn62", cos_connector_state="ready"}'
+        values: '1+1x8639'
+
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
+        values: '1+1x8639'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
+        values: '1+1x8639'
+
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x4319'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x8639'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '0+0x4319 1+1x4319'
+
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn62"}'
+        values: '1+1x8639'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn62"}'
+        values: '1+1x8639'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn62"}'
+        values: '0+0x4319'
+
+    promql_expr_test:
+      #Testing Availability SLO
+      - expr: slo_connector_availability_success_rate:ratio_rate7d
+        eval_time: 4319m
+        exp_samples:
+          - labels: 'slo_connector_availability_success_rate:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_availability_success_rate:ratio_rate7d
+        eval_time: 6d
+        exp_samples:
+          - labels: 'slo_connector_availability_success_rate:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 8.33333331472789E-01
+      - expr: slo_connector_availability_success_rate:ratio_rate28d
+        eval_time: 7d
+        exp_samples:
+          - labels: 'slo_connector_availability_success_rate:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 8.333349398047781E-01
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
+        eval_time: 4319m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
+        eval_time: 4319m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
+        eval_time: 7d
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 0
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
+        eval_time: 6d
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 0
+      #Testing Data Process SLO
+      - expr: slo_connector_data_success_rate:ratio_rate28d
+        eval_time: 7d
+        exp_samples:
+          - labels: 'slo_connector_data_success_rate:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 8.333429778369307E-01
+      - expr: slo_connector_data_success_rate:ratio_rate7d
+        eval_time: 4319m
+        exp_samples:
+          - labels: 'slo_connector_data_success_rate:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
+        eval_time: 4319m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
+        eval_time: 6d
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 0

--- a/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-2.yaml
+++ b/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-2.yaml
@@ -1,0 +1,73 @@
+rule_files:
+  - /prometheus/rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn60", cos_connector_state="ready"}'
+        values: '1+1x199'
+
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="ready"}'
+        values: '1+1x198'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="failed_but_ready"}'
+        values: '0+0x198 1'
+
+
+
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
+        values: '1+1x199'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
+        values: '1+1x199'
+
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x198'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x199'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '0+0x198 1'
+
+    promql_expr_test:
+      #Testing Remaining Error Budget for Availability
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
+        eval_time: 199m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 5.012468827930174E-01
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
+        eval_time: 199m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 5.012468827930174E-01
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
+        eval_time: 195m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
+        eval_time: 195m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      #Testing Remaining Error Budget for Exchanges
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
+        eval_time: 199m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 4.9999999999999994E-01
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
+        eval_time: 199m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 4.9999999999999994E-01
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
+        eval_time: 195m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
+        eval_time: 195m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1

--- a/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-2.yaml
+++ b/resources/prometheus/unit_tests/grafana-connectors-slo-rules-test-2.yaml
@@ -7,67 +7,86 @@ tests:
   - interval: 1m
     input_series:
       - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn60", cos_connector_state="ready"}'
-        values: '1+1x199'
+        values: '1+1x399'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn60", cos_connector_state="failed_but_ready"}'
+        values: '0+0x399'
 
-      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="ready"}'
-        values: '1+1x198'
-      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cchi5bvod5s2tjbeh7ag", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="failed_but_ready"}'
-        values: '0+0x198 1'
-
-
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cafmth1l8123ida8obm0", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="ready"}'
+        values: '1+1x398'
+      - series: 'cos_fleetshard_sync_connector_state_count_total{cluster_id="cafmth1l8123ida8obm0", cos_connector_id="cbvn81m9fbo9fmh5rn61", cos_connector_state="failed_but_ready"}'
+        values: '0+0x398 1'
 
       - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
-        values: '1+1x199'
+        values: '1+1x399'
       - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
-        values: '1+1x199'
+        values: '1+1x399'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn60"}'
+        values: '0+0x399'
 
-      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
-        values: '1+1x198'
-      - series: 'application_camel_context_exchanges_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
-        values: '1+1x199'
-      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cchi5bvod5s2tjbeh7ag", connector_id="cbvn81m9fbo9fmh5rn61"}'
-        values: '0+0x198 1'
+      - series: 'application_camel_context_exchanges_completed_total{cluster_id="cafmth1l8123ida8obm0", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x398'
+      - series: 'application_camel_context_exchanges_total{cluster_id="cafmth1l8123ida8obm0", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '1+1x399'
+      - series: 'application_camel_context_exchanges_failed_total{cluster_id="cafmth1l8123ida8obm0", connector_id="cbvn81m9fbo9fmh5rn61"}'
+        values: '0+0x398 1'
 
     promql_expr_test:
       #Testing Remaining Error Budget for Availability
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
-        eval_time: 199m
+        eval_time: 400m
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 5.012468827930174E-01
-      - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
-        eval_time: 199m
-        exp_samples:
-          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 5.012468827930174E-01
+            value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 4.9937578418090056E-01
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate28d
-        eval_time: 195m
+        eval_time: 398m
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
       - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
-        eval_time: 195m
+        eval_time: 400m
         exp_samples:
           - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 4.9937578418090056E-01
+      - expr: slo_connector_availability_remaining_error_budget:ratio_rate7d
+        eval_time: 398m
+        exp_samples:
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_availability_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
+
       #Testing Remaining Error Budget for Exchanges
       - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
-        eval_time: 199m
-        exp_samples:
-          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 4.9999999999999994E-01
-      - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
-        eval_time: 199m
-        exp_samples:
-          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
-            value: 4.9999999999999994E-01
-      - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
-        eval_time: 195m
+        eval_time: 400m
         exp_samples:
           - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
             value: 1
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 4.999968749804688E-01
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate28d
+        eval_time: 398m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate28d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 1
       - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
-        eval_time: 195m
+        eval_time: 400m
         exp_samples:
           - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
+            value: 4.999968749804688E-01
+      - expr: slo_connector_data_remaining_error_budget:ratio_rate7d
+        eval_time: 398m
+        exp_samples:
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cchi5bvod5s2tjbeh7ag", tenant="rhoc"}'
+            value: 1
+          - labels: 'slo_connector_data_remaining_error_budget:ratio_rate7d{cluster_id="cafmth1l8123ida8obm0", tenant="rhoc"}'
             value: 1


### PR DESCRIPTION
## Description
This PR is part of MGDCTRS-1703 where I just added Recording rules for the data-plane SLO Grafana dashboard.
This change will only allow the Grafana to use the recorded rule. Unit tests are not part of this PR.

## Verification Steps
1. Let this PR get merged so that the changes get deployed to the stage observatorium.
2. Validate the recording rules on the stage observatorium tenant.

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [x] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Verified independently by reviewer
~~- [ ] Required Standard Operating Procedure (SOP) is added.~~

## Prometheus
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies prometheus resources
-->
~~- [ ] Changes were tested against dev environment~~

## Grafana
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies grafana resources
-->
~~- [ ] You have imported the changes into a dev or staging environment~~