### PR TITLE
MGDCTRS-1793 : Add `container_cpu_usage_seconds_total` metrics to observatorium

### DIFF
--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -24,6 +24,15 @@ writeRelabelConfigs:
     sourceLabels:
       - __name__
     targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_cpu_usage_seconds_total.*$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
   # WHAT: Reports the current amount of Prometheus remote storage shards
   - action: replace
     regex: prometheus_remote_storage_shards$


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Adding a metrics to observatorium for trial testing.
https://issues.redhat.com/browse/MGDCTRS-1793

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [x] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [x] Verified independently by reviewer
- [ ] Required Standard Operating Procedure (SOP) is added.

## Prometheus
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies prometheus resources
-->
- [ ] Changes were tested against dev environment

## Grafana
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies grafana resources
-->
- [ ] You have imported the changes into a dev or staging environment