### PR TITLE
MGDCTRS-1793 : Allowing Pod/Containers resource metrics to display in Dataplane Operator Dashboard

### DIFF
--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -24,6 +24,15 @@ writeRelabelConfigs:
     sourceLabels:
       - __name__
     targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_cpu_usage_seconds_total.*$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
   # WHAT: Reports the current amount of Prometheus remote storage shards
   - action: replace
     regex: prometheus_remote_storage_shards$

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -1,7 +1,7 @@
 writeRelabelConfigs:
   # Drop useless labels
   - action: labeldrop
-    regex: endpoint|instance|job|prometheus|pod
+    regex: endpoint|instance|job|prometheus|pod|kube|container
 
   # WHAT: Reports the current amount of samples that have failed to be sent to observatorium
   - action: replace
@@ -35,22 +35,6 @@ writeRelabelConfigs:
 
   # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
   - action: replace
-    regex: container_cpu_usage_seconds_total*$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-     targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_cpu_usage_seconds_total$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
     regex: kube_pod_info$
     replacement: 'true'
     sourceLabels:
@@ -75,23 +59,7 @@ writeRelabelConfigs:
 
   # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
   - action: replace
-    regex: kube_pod_container_resource_requests$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_memory_working_set_bytes.*$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: kube_pod_container_resource_limits.*$
+    regex: kube_pod_container_resource_limits$
     replacement: 'true'
     sourceLabels:
       - __name__

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -43,14 +43,6 @@ writeRelabelConfigs:
 
   # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
   - action: replace
-    regex: kube_pod_container_resource_requests$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
     regex: container_memory_working_set_bytes$
     replacement: 'true'
     sourceLabels:

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -50,8 +50,9 @@ writeRelabelConfigs:
     targetLabel: __tmp_keep
 
   # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: kube_pod_container_resource_limits$
+  - action: keep
+    #regex: kube_pod_container_resource_limits$
+    regex: kube_pod_.*|container_network_.*|container_memory_.*
     replacement: 'true'
     sourceLabels:
       - __name__

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -1,7 +1,7 @@
 writeRelabelConfigs:
   # Drop useless labels
   - action: labeldrop
-    regex: endpoint|instance|job|prometheus|pod|kube|container
+    regex: endpoint|instance|job|prometheus
 
   # WHAT: Reports the current amount of samples that have failed to be sent to observatorium
   - action: replace

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -33,6 +33,110 @@ writeRelabelConfigs:
       - __name__
     targetLabel: __tmp_keep
 
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_cpu_usage_seconds_total*$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+     targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_cpu_usage_seconds_total$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: kube_pod_info$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: kube_pod_container_resource_requests$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_memory_working_set_bytes$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: kube_pod_container_resource_requests$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_memory_working_set_bytes.*$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: kube_pod_container_resource_limits.*$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: kube_pod_container_resource_requests$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_network_receive_bytes_total$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_network_receive_packets_dropped_total$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_network_receive_packets_total$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
+  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
+  - action: replace
+    regex: container_network_receive_errors_total$
+    replacement: 'true'
+    sourceLabels:
+      - __name__
+    targetLabel: __tmp_keep
+
   # WHAT: Reports the current amount of Prometheus remote storage shards
   - action: replace
     regex: prometheus_remote_storage_shards$
@@ -40,6 +144,7 @@ writeRelabelConfigs:
     sourceLabels:
       - __name__
     targetLabel: __tmp_keep
+
   # WHAT: Reports the desired amount of Prometheus remote storage shards
   - action: replace
     regex: prometheus_remote_storage_shards_desired$
@@ -47,6 +152,7 @@ writeRelabelConfigs:
     sourceLabels:
       - __name__
     targetLabel: __tmp_keep
+
   # WHAT: Reports maximum amount of Prometheus remote storage shards
   - action: replace
     regex: prometheus_remote_storage_shards_max$

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -34,7 +34,7 @@ writeRelabelConfigs:
     targetLabel:
       -
   # WHAT: Reports the pods only for the defined metrics that have tried to be resent to observatorium
-  - source_labels: [ __kube_pod, __container_network, __container_memory, __container_cpu ]
+  - source_labels: kube_pod_.*|container_network_.*|container_memory_.*|container_cpu_.*
     separator: ;
     regex: (.*)
     target_label: pod

--- a/resources/prometheus/remote-write.yaml
+++ b/resources/prometheus/remote-write.yaml
@@ -27,76 +27,19 @@ writeRelabelConfigs:
 
   # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
   - action: replace
-    regex: container_cpu_usage_seconds_total.*$
+    regex: kube_pod_.*|container_network_.*|container_memory_.*|container_cpu_.*
     replacement: 'true'
     sourceLabels:
       - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: kube_pod_info$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_memory_working_set_bytes$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: keep
-    #regex: kube_pod_container_resource_limits$
-    regex: kube_pod_.*|container_network_.*|container_memory_.*
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: kube_pod_container_resource_requests$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_network_receive_bytes_total$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_network_receive_packets_dropped_total$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_network_receive_packets_total$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
-
-  # WHAT: Reports the current amount of samples that have tried to be resent to observatorium
-  - action: replace
-    regex: container_network_receive_errors_total$
-    replacement: 'true'
-    sourceLabels:
-      - __name__
-    targetLabel: __tmp_keep
+    targetLabel:
+      -
+  # WHAT: Reports the pods only for the defined metrics that have tried to be resent to observatorium
+  - source_labels: [ __kube_pod, __container_network, __container_memory, __container_cpu ]
+    separator: ;
+    regex: (.*)
+    target_label: pod
+    replacement: ${1}
+    action: labelkeep
 
   # WHAT: Reports the current amount of Prometheus remote storage shards
   - action: replace


### PR DESCRIPTION
<!-- Please use the PR template and provide as much relevant information as you can, otherwise your PR may not get reviewed. -->

## Description
Adding the following metrics to observatorium 
1.kube_pod_info
2.kube_pod_container_resource_requests
3.container_memory_working_set_bytes
4.kube_pod_container_resource_limits
5.kube_pod_container_resource_requests
6.container_network_receive_bytes_total
7.container_network_receive_packets_dropped_total
8.container_network_receive_packets_total
9.container_network_receive_errors_total

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item 
4. Check if in the left menu the feature X is not so long present.

If manual verifications required, please provide an environment where the reviewers can easily validate the changes if possible to speed up the review process. 
-->

## Checklist (Definition of Done)
<!-- Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options -->
- [ ] All acceptance criteria specified in JIRA have been completed
- [ ] Unit and integration tests added that prove the fix is effective or the feature works (tested against emulated and non-emulated OCM environment)
- [ ] Verified independently by reviewer
- [ ] Required Standard Operating Procedure (SOP) is added.

## Prometheus
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies prometheus resources
-->
- [ ] Changes were tested against dev environment

## Grafana
<!-- 
Please strikethrough options not relevant using two tildes ~~Text~~. Do not delete non relevant options

If your PR modifies grafana resources
-->
- [ ] You have imported the changes into a dev or staging environment